### PR TITLE
Remove LICENSE from compiled sources

### DIFF
--- a/Bankside.xcodeproj/project.pbxproj
+++ b/Bankside.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2D09E1431BC8F0DC002B95B9 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = 2D09E1421BC8F0DC002B95B9 /* README.md */; settings = {ASSET_TAGS = (); }; };
 		2D09E1451BC8F0EE002B95B9 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 2D09E1411BC8F0DC002B95B9 /* LICENSE */; };
 		2D09E1471BC8F0F8002B95B9 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 2D09E1411BC8F0DC002B95B9 /* LICENSE */; };
 		2D09E14A1BC8F644002B95B9 /* dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D09E1491BC8F644002B95B9 /* dictionary.swift */; settings = {ASSET_TAGS = (); }; };
@@ -326,7 +325,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D09E14A1BC8F644002B95B9 /* dictionary.swift in Sources */,
-				2D09E1431BC8F0DC002B95B9 /* README.md in Sources */,
 				2DB43A3E1BBDB97F001BCF97 /* factory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
The license was incorrectly added as a compiled source, which resulted
in warnings when compiling the project as Xcode doesn't have a markdown
compiler.
