### PR TITLE
Require options to be bool

### DIFF
--- a/sources/factory.swift
+++ b/sources/factory.swift
@@ -3,9 +3,9 @@ import Foundation
 public class Factory<T> {
 
   public typealias CreateClosure = (attributes: [String: Any]) -> T
-  public typealias AttributeClosure = (options: [String: Any]) -> Any
-  public typealias OptionClosure = () -> Any
-  public typealias AfterClosure = (item: T, options: [String: Any]) -> Void
+  public typealias AttributeClosure = (options: [String: Bool]) -> Any
+  public typealias OptionClosure = () -> Bool
+  public typealias AfterClosure = (item: T, options: [String: Bool]) -> Void
   public typealias SequenceClosure = (Int) -> Any
   public typealias TransformClosure = (value: Any) -> [String: Any]
 
@@ -120,7 +120,7 @@ public class Factory<T> {
   /// - parameter attributes: additional attributes
   /// - parameter options: additional options
   /// - returns: The built object
-  public func build(attributes: [String: Any] = [:], options: [String: Any] = [:]) -> T {
+  public func build(attributes: [String: Any] = [:], options: [String: Bool] = [:]) -> T {
     let options = self.options(options)
     let attributes = self.attributes(attributes, options: options)
     let item = self.create(attributes: attributes)
@@ -130,7 +130,7 @@ public class Factory<T> {
     return item
   }
 
-  func attributes(var attributes: [String: Any], options: [String: Any]) -> [String: Any] {
+  func attributes(var attributes: [String: Any], options: [String: Bool]) -> [String: Any] {
     for (key, value) in self.attributes where attributes[key] == nil {
       attributes[key] = value(options: options)
     }
@@ -144,7 +144,7 @@ public class Factory<T> {
     return attributes
   }
 
-  func options(var options: [String: Any]) -> [String: Any] {
+  func options(var options: [String: Bool]) -> [String: Bool] {
     for (key, value) in self.options where options[key] == nil {
       options[key] = value()
     }

--- a/tests/factory_spec.swift
+++ b/tests/factory_spec.swift
@@ -72,7 +72,7 @@ class FactorySpec: QuickSpec {
       it("passes in options") {
         waitUntil(timeout: 5) { done in
           factory.attr("id") { options in
-            expect(options["value"] as? Bool).to(equal(true))
+            expect(options["value"]!).to(equal(true))
             defer { done() }
             return "hey"
           }
@@ -88,24 +88,12 @@ class FactorySpec: QuickSpec {
 
       it("defines option") {
         let options = factory.options([:])
-        expect(options["store"] as? Bool).to(equal(true))
+        expect(options["store"]).to(equal(true))
       }
 
       it("overwrites option") {
         let options = factory.options(["store": false])
-        expect(options["store"] as? Bool).to(equal(false))
-      }
-    }
-
-    describe("#option(key, closure)") {
-      beforeEach {
-        factory.option("store", value: NSUUID().UUIDString)
-      }
-      it("uses closure value") {
-        let optionsA = factory.options([:])
-        let optionsB = factory.options([:])
-        expect(optionsA["store"] is String).to(equal(true))
-        expect(optionsA["store"] as? String).notTo(equal(optionsB["store"] as? String))
+        expect(options["store"]).to(equal(false))
       }
     }
 
@@ -151,7 +139,7 @@ class FactorySpec: QuickSpec {
       it("passes in options") {
         waitUntil(timeout: 5) { done in
           factory.after { item, options in
-            expect(options["works"] as? Bool).to(equal(true))
+            expect(options["works"]!).to(equal(true))
             done()
           }
           factory.build(options: ["works": true])


### PR DESCRIPTION
After using Bankside for a while I realized that all options I ever
used was in fact booleans and it was rather annoying casting them.
